### PR TITLE
Update streamline_registration.py tutorial to work with B0 template data

### DIFF
--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -1,0 +1,268 @@
+"""
+=======================
+Streamline Registration
+=======================
+
+This example shows how to register streamlines into a template space by
+applying non-rigid deformations.
+
+At times we will be interested in bringing a set of streamlines into some
+common, reference space to compute statistics out of the registered
+streamlines.
+
+For brevity, we will include in this example only streamlines going through
+the corpus callosum connecting left to right superior frontal
+cortex. The process of tracking and finding these streamlines is fully
+demonstrated in the :ref:`streamline_tools` example. If this example has been
+run, we can read the streamlines from file. Otherwise, we'll run that example
+first, by importing it. This provides us with all of the variables that were
+created in that example.
+
+In order to get the deformation field, we will first use two b0 volumes. The
+first one will be the b0 from the Stanford HARDI dataset:
+
+"""
+
+import os.path as op
+
+if not op.exists('lr-superiorfrontal.trk'):
+    from streamline_tools import *
+else:
+    from dipy.data import read_stanford_hardi
+    hardi_img, gtab = read_stanford_hardi()
+    data = hardi_img.get_data()
+
+"""
+The second one will be the T2-contrast MNI template image.
+
+"""
+
+from dipy.data.fetcher import (fetch_mni_template, read_mni_template)
+
+fetch_mni_template()
+img_t2_mni = read_mni_template("a", contrast = "T2")
+
+"""
+We filter the diffusion data from the Stanford HARDI dataset to find the b0
+images.
+
+"""
+
+import numpy as np
+
+b0_idx_stanford = np.where(gtab.b0s_mask)[0]
+b0_data_stanford = data[..., b0_idx_stanford]
+
+"""
+We then remove the skull from the b0's.
+
+"""
+
+from dipy.segment.mask import median_otsu
+
+b0_masked_stanford, _ = median_otsu(b0_data_stanford,
+                                    vol_idx=[i for i in range(b0_data_stanford.shape[-1])],
+                                    median_radius=4, numpass=4)
+
+"""
+And go on to compute the Stanford HARDI dataset mean b0 image.
+
+"""
+
+mean_b0_masked_stanford = np.mean(b0_masked_stanford, axis=3,
+                                  dtype=data.dtype)
+
+"""
+We will register the mean b0 to the MNI T2 image template non-rigidly to
+obtain the deformation field that will be applied to the streamlines. We will
+first perform an affine registration to roughly align the two volumes:
+
+"""
+
+from dipy.align.imaffine import (AffineMap, MutualInformationMetric,
+                                 AffineRegistration)
+from dipy.align.transforms import (TranslationTransform3D, RigidTransform3D,
+                                   AffineTransform3D)
+
+static = img_t2_mni.get_data()
+static_affine = img_t2_mni.affine
+moving = mean_b0_masked_stanford
+moving_affine = hardi_img.affine
+
+identity = np.eye(4)
+affine_map = AffineMap(identity, static.shape, static_affine, moving.shape,
+                       moving_affine)
+resampled = affine_map.transform(moving)
+
+"""
+We specify the mismatch metric:
+
+"""
+
+nbins = 32
+sampling_prop = None
+metric = MutualInformationMetric(nbins, sampling_prop)
+
+"""
+As well as the optimization strategy:
+
+"""
+
+level_iters = [10, 10, 5]
+sigmas = [3.0, 1.0, 0.0]
+factors = [4, 2, 1]
+affine_reg = AffineRegistration(metric=metric, level_iters=level_iters,
+                                sigmas=sigmas, factors=factors)
+transform = TranslationTransform3D()
+
+params0 = None
+translation = affine_reg.optimize(static, moving, transform, params0,
+                                  static_affine, moving_affine)
+transformed = translation.transform(moving)
+transform = RigidTransform3D()
+
+rigid_map = affine_reg.optimize(static, moving, transform, params0,
+                                static_affine, moving_affine,
+                                starting_affine=translation.affine)
+transformed = rigid_map.transform(moving)
+transform = AffineTransform3D()
+
+"""
+We bump up the iterations to get a more exact fit:
+
+"""
+
+affine_reg.level_iters = [1000, 1000, 100]
+affine_map = affine_reg.optimize(static, moving, transform, params0,
+                                 static_affine, moving_affine,
+                                 starting_affine=rigid_map.affine)
+transformed = affine_map.transform(moving)
+
+
+"""
+We now perform the non-rigid deformation using the Symmetric Diffeomorphic
+Registration (SyN) Algorithm:
+
+"""
+
+from dipy.align.imwarp import SymmetricDiffeomorphicRegistration
+from dipy.align.metrics import CCMetric
+
+metric = CCMetric(3)
+level_iters = [10, 10, 5]
+sdr = SymmetricDiffeomorphicRegistration(metric, level_iters)
+
+mapping = sdr.optimize(static, moving, static_affine, moving_affine,
+                       affine_map.affine)
+warped_moving = mapping.transform(moving)
+warped_static = mapping.transform_inverse(moving)
+
+"""
+We show the registration result with:
+
+"""
+from dipy.viz import regtools
+
+regtools.overlay_slices(static, warped_moving, None, 0, "Static", "Moving",
+                        "transformed_sagittal.png")
+regtools.overlay_slices(static, warped_moving, None, 1, "Static", "Moving",
+                        "transformed_coronal.png")
+regtools.overlay_slices(static, warped_moving, None, 2, "Static", "Moving",
+                        "transformed_axial.png")
+
+"""
+.. figure:: transformed_sagittal.png
+   :align: center
+.. figure:: transformed_coronal.png
+   :align: center
+.. figure:: transformed_axial.png
+   :align: center
+
+   Deformable registration result.
+"""
+
+"""
+We read the streamlines from file in voxel space:
+
+"""
+
+from dipy.io.streamline import load_trk
+
+streamlines, hdr = load_trk('lr-superiorfrontal.trk')
+
+
+"""
+We then apply the obtained deformation field to the streamlines. We first
+apply the computed affine transformation, and then the non-rigid warping:
+
+"""
+
+from dipy.tracking.streamline import deform_streamlines
+
+from dipy.tracking.utils import move_streamlines
+
+rotation, scale = np.linalg.qr(affine_map.affine)
+streams = move_streamlines(streamlines, rotation)
+scale[0:3, 0:3] = np.dot(scale[0:3, 0:3], np.diag(1. / hdr['voxel_sizes']))
+scale[0:3, 3] = abs(scale[0:3, 3])
+affine_streamlines = move_streamlines(streamlines, scale)
+
+warped_streamlines = \
+    deform_streamlines(affine_streamlines,
+                       deform_field=mapping.get_forward_field(),
+                       stream_to_current_grid=moving_affine,
+                       current_grid_to_world=mapping.codomain_grid2world,
+                       stream_to_ref_grid=static_affine,
+                       ref_grid_to_world=mapping.domain_grid2world)
+
+
+"""
+We display the original streamlines and the registered streamlines:
+
+"""
+
+from dipy.viz import window, actor, have_fury
+
+from time import sleep
+
+def show_both_bundles(bundles, colors=None, show=True, fname=None):
+
+    renderer = window.Renderer()
+    for (i, bundle) in enumerate(bundles):
+        color = colors[i]
+        lines_actor = actor.streamtube(bundle, color, linewidth=0.3)
+        lines_actor.RotateX(-90)
+        lines_actor.RotateZ(90)
+        renderer.add(lines_actor)
+    if show:
+        window.show(renderer)
+    if fname is not None:
+        sleep(1)
+        window.record(renderer, n_frames=1, out_path=fname, size=(900, 900))
+
+if have_fury:
+    """
+    .. figure:: streamline_registration.png
+       :align: center
+
+       Streamlines before and after registration.
+
+    As it can be seen, the corpus callosum bundles have been deformed to adapt
+    to the MNI template space.
+
+    """
+
+    show_both_bundles([streamlines, warped_streamlines],
+                      colors=[window.colors.orange, window.colors.red],
+                      show=False,
+                      fname='streamline_registration.png')
+
+"""
+Finally, we save the registered streamlines:
+
+"""
+
+from dipy.io.streamline import save_trk
+
+save_trk("warped-lr-superiorfrontal.trk", warped_streamlines,
+         affine_map.affine)

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -12,20 +12,15 @@ streamlines. For a discussion on the effects of spatial normalization
 approaches on tractography the work by Green et al. [Greene17]_ can be read.
 
 For brevity, we will include in this example only streamlines going through
-the corpus callosum connecting left to right superior frontal
-cortex. The process of tracking and finding these streamlines is fully
-demonstrated in the :ref:`streamline_tools` example. If this example has been
-run, we can read the streamlines from file. Otherwise, we'll run that example
-first, by importing it. This provides us with all of the variables that were
-created in that example.
+the corpus callosum connecting left to right superior frontal cortex. The
+process of tracking and finding these streamlines is fully demonstrated in
+the :ref:`streamline_tools` example. If this example has been run, we can read
+the streamlines from file. Otherwise, we'll run that example first, by
+importing it. This provides us with all of the variables that were created in
+that example.
 
-In order to get the deformation field, we will first generate a mean b0 volume
-(to restrict brain boundaries) and an FA map (to yield a high-contrast wm tissue
-image that is ideal for optimizing subcortical registration). To accomplish
-this, we will use the Stanford HARDI dataset, and an mni-space FA template from
-HCP. Since this process can be sensitive to image orientation and voxel resolution,
-we will demonstrate it using a moving image and a template image that are uniformly
-in 2mm isotropic resolution and in RAS+ orientation.
+In order to get the deformation field, we will first use two b0 volumes. The
+first one will be the b0 from the Stanford HARDI dataset:
 
 """
 
@@ -40,12 +35,14 @@ else:
     vox_size = hardi_img.header.get_zooms()[0]
 
 """
-The second one will be the template FA map from the HCP1065 dataset:
+The second one will be the T2-contrast MNI template image.
 
 """
 
-template_path = '/Users/derekpisner/Applications/PyNets/pynets/templates/FSL_HCP1065_FA_2mm.nii.gz'
-template_img = nib.load(template_path)
+from dipy.data.fetcher import (fetch_mni_template, read_mni_template)
+
+fetch_mni_template()
+img_t2_mni = read_mni_template("a", contrast = "T2")
 
 """
 We filter the diffusion data from the Stanford HARDI dataset to find the b0
@@ -59,14 +56,14 @@ b0_idx_stanford = np.where(gtab.b0s_mask)[0]
 b0_data_stanford = data[..., b0_idx_stanford]
 
 """
-We then remove the skull from the b0's.
+We then remove the skull from them:
 
 """
 
 from dipy.segment.mask import median_otsu
 
 b0_masked_stanford, _ = median_otsu(b0_data_stanford,
-                vol_idx=[i for i in range(b0_data_stanford.shape[-1])],
+                vol_idx=list(range(b0_data_stanford.shape[-1])),
                 median_radius=4, numpass=4)
 
 
@@ -79,26 +76,14 @@ mean_b0_masked_stanford = np.mean(b0_masked_stanford, axis=3,
                                   dtype=data.dtype)
 
 """
-We use the mean b0 image, along with the HARDI data itself to estimate an FA
-image.
+We will register the mean b0 to the MNI T2 image template non-rigidly to
+obtain the deformation field that will be applied to the streamlines. This is
+just one of the strategies that can be used to obtain an appropriate
+deformation field. Other strategies include computing an FA map as the static
+image or template, which may eventually lead to results with improved
+accuracy.
 
-"""
-
-from dipy.reconst.dti import TensorModel
-from dipy.reconst.dti import fractional_anisotropy
-
-B0_mask_data = mean_b0_masked_stanford.astype('bool')
-hardi_img_affine = hardi_img.affine
-model = TensorModel(gtab)
-mod = model.fit(data, B0_mask_data)
-FA = fractional_anisotropy(mod.evals)
-FA[np.isnan(FA)] = 0
-
-
-"""
-We will register the mean b0-masked FA map to the template FA map non-rigidly to obtain the
-deformation field that will be applied to the streamlines. We will first
-perform an affine registration to roughly align the two volumes:
+We will first perform an affine registration to roughly align the two volumes:
 
 """
 
@@ -107,10 +92,15 @@ from dipy.align.imaffine import (AffineMap, MutualInformationMetric,
 from dipy.align.transforms import (TranslationTransform3D, RigidTransform3D,
                                    AffineTransform3D)
 
-static = template_img.get_data()
-static_affine = template_img.affine
+static = img_t2_mni.get_data()
+static_affine = img_t2_mni.affine
 moving = mean_b0_masked_stanford
 moving_affine = hardi_img.affine
+
+identity = np.eye(4)
+affine_map = AffineMap(identity, static.shape, static_affine, moving.shape,
+                       moving_affine)
+resampled = affine_map.transform(moving)
 
 """
 We estimate an affine that maps the origin of the moving image to that of the
@@ -189,12 +179,12 @@ We show the registration result with:
 """
 from dipy.viz import regtools
 
-regtools.overlay_slices(static, warped_moving, None, 0, "Static", "Moving",
-                        "transformed_sagittal.png")
-regtools.overlay_slices(static, warped_moving, None, 1, "Static", "Moving",
-                        "transformed_coronal.png")
-regtools.overlay_slices(static, warped_moving, None, 2, "Static", "Moving",
-                        "transformed_axial.png")
+regtools.overlay_slices(static, warped_moving, None, 0, 'Static', 'Moving',
+                        'transformed_sagittal.png')
+regtools.overlay_slices(static, warped_moving, None, 1, 'Static', 'Moving',
+                        'transformed_coronal.png')
+regtools.overlay_slices(static, warped_moving, None, 2, 'Static', 'Moving',
+                        'transformed_axial.png')
 
 """
 .. figure:: transformed_sagittal.png
@@ -212,44 +202,73 @@ We read the streamlines from file in voxel space:
 
 """
 
-from dipy.io.streamline import load_trk
-streamlines, hdr = load_trk('lr-superiorfrontal.trk')
+from dipy.io.streamline import load_tractogram
 
-
-"""
-We then apply the obtained deformation field to the streamlines. We first
-apply the non-rigid warping and simultaneously apply a computed rigid affine
-transformation whose extents must be corrected to account for the different
-voxel grids of the moving and static images:
+sft = load_tractogram('lr-superiorfrontal.trk', 'same')
 
 """
+We then apply the obtained deformation field to the streamlines. Note that the
+process can be sensitive to image orientation and voxel resolution. Thus, we
+first apply the non-rigid warping and simultaneously apply a computed rigid
+affine transformation whose extents must be corrected to account for the
+different voxel grids of the moving and static images.
+
+"""
+
 from dipy.tracking.streamline import deform_streamlines
 
 # Create an isocentered affine
 target_isocenter = np.diag(np.array([-vox_size, vox_size, vox_size, 1]))
 
-# Take the off-origin affine capturing the extent contrast between fa image and the template
+# Take the off-origin affine capturing the extent contrast between the mean b0
+# image and the template
 origin_affine = affine_map.affine.copy()
 
-# Now we flip the sign in the x and y planes so that we get the mirror image of the forward deformation field.
+"""
+In order to align the FOV of the template and the mirror image of the
+streamlines, we first need to flip the sign on the x-offset and y-offset so
+that we get the mirror image of the forward deformation field.
+
+We need to use the information about the origin offsets (i.e. between the
+static and moving images) that we obtained using :meth:`transform_origins`:
+
+"""
+
 origin_affine[0][3] = -origin_affine[0][3]
 origin_affine[1][3] = -origin_affine[1][3]
 
-# Scale z by the voxel size
+"""
+
+:meth:`transform_origins` returns this affine transformation with (1, 1, 1)
+zooms and not (2, 2, 2), which means that the offsets need to be scaled by 2.
+Thus, we scale z by the voxel size:
+ 
+"""
+
 origin_affine[2][3] = origin_affine[2][3]/vox_size
 
-# Scale y by the square of the voxel size since we've already scaled along the z-plane.
-origin_affine[1][3] = origin_affine[1][3]/vox_size**vox_size
-
-# Apply the deformation and correct for the extents
-mni_streamlines = deform_streamlines(streamlines, deform_field=mapping.get_forward_field(),
-                                     stream_to_current_grid=target_isocenter,
-                                     current_grid_to_world=origin_affine,
-                                     stream_to_ref_grid=target_isocenter,
-                                     ref_grid_to_world=np.eye(4))
+"""
+But when scaling the z-offset, we are also implicitly scaling the y-offset as
+well (by 1/2).Thus we need to correct for this by only scaling the y by the
+square of the voxel size (1/4, and not 1/2):
 
 """
-We display the original streamlines and the registered streamlines:
+
+origin_affine[1][3] = origin_affine[1][3]/vox_size**vox_size
+
+"""
+Finally, we apply the deformation and correct for the extents:
+
+"""
+
+warped_streamlines = deform_streamlines(
+    sft.streamlines, deform_field=mapping.get_forward_field(),
+    stream_to_current_grid=target_isocenter,
+    current_grid_to_world=origin_affine, stream_to_ref_grid=target_isocenter,
+    ref_grid_to_world=np.eye(4))
+
+"""
+We display the warped streamlines overlaid to the template image:
 
 """
 
@@ -258,15 +277,16 @@ from dipy.viz import has_fury
 def show_template_bundles(bundles, show=True, fname=None):
 
     renderer = window.Renderer()
-    template_img_data = template_img.get_data().astype('bool')
-    template_actor = actor.contour_from_roi(template_img_data, color=(50, 50, 50), opacity=0.1)
+    template_actor = actor.slicer(static)
     renderer.add(template_actor)
-    lines_actor = actor.streamtube(bundles, window.colors.orange, linewidth=0.3)
+
+    lines_actor = actor.streamtube(bundles, window.colors.orange,
+                                   linewidth=0.3)
     renderer.add(lines_actor)
+
     if show:
         window.show(renderer)
     if fname is not None:
-        sleep(1)
         window.record(renderer, n_frames=1, out_path=fname, size=(900, 900))
 
 
@@ -274,19 +294,17 @@ if has_fury:
 
     from fury import actor, window
 
-    from time import sleep
-
-    show_template_bundles(affine_streamlines, show=False,
+    show_template_bundles(warped_streamlines, show=False,
                           fname='streamline_registration.png')
 
     """
     .. figure:: streamline_registration.png
        :align: center
 
-       Streamlines before and after registration.
+       Streamlines after registration.
 
-    As it can be seen, the corpus callosum bundles have been deformed to adapt
-    to the MNI template space.
+    The corpus callosum bundles have been deformed to adapt to the MNI
+    template space.
 
     """
 
@@ -295,10 +313,12 @@ Finally, we save the registered streamlines:
 
 """
 
-from dipy.io.streamline import save_trk
+from dipy.io.stateful_tractogram import Space, StatefulTractogram
+from dipy.io.streamline import save_tractogram
 
-save_trk("warped-lr-superiorfrontal.trk", warped_streamlines,
-         affine_map.affine)
+sft = StatefulTractogram(warped_streamlines, img_t2_mni, Space.RASMM)
+
+save_tractogram(sft, 'warped-lr-superiorfrontal.trk', bbox_valid_check=True)
 
 
 """

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -142,7 +142,8 @@ transformed = affine_map.transform(moving)
 
 """
 We now perform the non-rigid deformation using the Symmetric Diffeomorphic
-Registration (SyN) Algorithm:
+Registration (SyN) Algorithm proposed by Avants et al. [Avants09]_ (also
+implemented in the ANTs software [Avants11]_):
 
 """
 
@@ -269,3 +270,20 @@ from dipy.io.streamline import save_trk
 
 save_trk("warped-lr-superiorfrontal.trk", warped_streamlines,
          affine_map.affine)
+
+
+"""
+References
+----------
+
+.. [Avants09] Avants, B. B., Epstein, C. L., Grossman, M., & Gee, J. C. (2009).
+   Symmetric Diffeomorphic Image Registration with Cross-Correlation:
+   Evaluating Automated Labeling of Elderly and Neurodegenerative Brain, 12(1),
+   26-41.
+
+.. [Avants11] Avants, B. B., Tustison, N., & Song, G. (2011). Advanced
+   Normalization Tools (ANTS), 1-35.
+
+.. include:: ../links_names.inc
+
+"""

--- a/doc/examples/streamline_registration.py
+++ b/doc/examples/streamline_registration.py
@@ -40,7 +40,7 @@ The second one will be the T2-contrast MNI template image.
 from dipy.data.fetcher import (fetch_mni_template, read_mni_template)
 
 fetch_mni_template()
-img_t2_mni = read_mni_template("a", contrast = "T2")
+img_t2_mni = read_mni_template("a", contrast="T2")
 
 """
 We filter the diffusion data from the Stanford HARDI dataset to find the b0
@@ -60,9 +60,10 @@ We then remove the skull from the b0's.
 
 from dipy.segment.mask import median_otsu
 
-b0_masked_stanford, _ = median_otsu(b0_data_stanford,
-                                    vol_idx=[i for i in range(b0_data_stanford.shape[-1])],
-                                    median_radius=4, numpass=4)
+b0_masked_stanford, _ = \
+    median_otsu(b0_data_stanford,
+                vol_idx=[i for i in range(b0_data_stanford.shape[-1])],
+                median_radius=4, numpass=4)
 
 """
 And go on to compute the Stanford HARDI dataset mean b0 image.
@@ -225,6 +226,7 @@ from dipy.viz import window, actor, have_fury
 
 from time import sleep
 
+
 def show_both_bundles(bundles, colors=None, show=True, fname=None):
 
     renderer = window.Renderer()
@@ -239,6 +241,7 @@ def show_both_bundles(bundles, colors=None, show=True, fname=None):
     if fname is not None:
         sleep(1)
         window.record(renderer, n_frames=1, out_path=fname, size=(900, 900))
+
 
 if have_fury:
     """

--- a/doc/examples/valid_examples.txt
+++ b/doc/examples/valid_examples.txt
@@ -53,6 +53,7 @@
  syn_registration_3d.py
  tissue_classification.py
  bundle_registration.py
+ streamline_registration.py
 # piesno.py
  viz_advanced.py
  viz_slice.py

--- a/doc/examples_index.rst
+++ b/doc/examples_index.rst
@@ -193,6 +193,7 @@ Streamline-based Registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :ref:`example_bundle_registration`
+- :ref:`example_streamline_registration`
 
 ------------
 Segmentation


### PR DESCRIPTION
*Affine code still valid
*t2_mni template data needed to be resliced to 2mm voxels to match that of the HARDI data.
*In the previous iteration of this, I think you might have forgot to change the lines that set the affine_map, which need to use the transform_origins function to work as expected.